### PR TITLE
Add --port flag support

### DIFF
--- a/cmd/ebpf-mcp/main.go
+++ b/cmd/ebpf-mcp/main.go
@@ -20,6 +20,8 @@ var debugMode bool
 
 func main() {
 	var transport string
+	var port string
+	flag.StringVar(&port, "port", "8080", "Port to listen on")
 	flag.StringVar(&transport, "t", "stdio", "Transport type (stdio or http)")
 	flag.StringVar(&transport, "transport", "stdio", "Transport type (stdio or http)")
 	flag.BoolVar(&debugMode, "debug", false, "Enable debug logging")
@@ -66,7 +68,7 @@ func main() {
 			w.Header().Set("Content-Type", "application/json")
 			response := map[string]interface{}{
 				"schema_version": "v1",
-				"entrypoint_url": "http://localhost:8080/mcp",
+				"entrypoint_url": "http://localhost:" + port + "/mcp",
 				"display_name":   "eBPF MCP Server",
 				"description":    "Exposes Linux kernel tools via MCP protocol",
 				"tool_filter":    "all",
@@ -78,11 +80,11 @@ func main() {
 		authenticated := tokenAuthMiddleware(token, httpServer)
 		mux.Handle("/mcp", authenticated)
 
-		log.Printf("\U0001F527 ebpf-mcp HTTP server listening on :8080")
-		log.Printf("   MCP endpoint: http://localhost:8080/mcp")
-		log.Printf("   Discovery: http://localhost:8080/.well-known/mcp/metadata.json")
+		log.Printf("\U0001F527 ebpf-mcp HTTP server listening on :%s", port)
+		log.Printf("   MCP endpoint: http://localhost:%s/mcp", port)
+		log.Printf("   Discovery: http://localhost:%s/.well-known/mcp/metadata.json", port)
 
-		if err := http.ListenAndServe(":8080", mux); err != nil {
+		if err := http.ListenAndServe(":" + port, mux); err != nil {
 			log.Fatalf("Server error: %v", err)
 		}
 	} else {


### PR DESCRIPTION
## Fix for #12

### Summary - Implemented support for `--port` flag, allowing users to specify a custom port for the eBPF MCP Server.

### Changes 

- Update **main.go** to accept port flag
```go
var port string
flag.StringVar(&port, "port", "8080", "Port to listen on")
```	
and made endpoints dynamic to accept custom port

- Update **install.sh**, 

```bash
local exec_opts="-t http"
if "${INSTALL_DIR}/${BINARY_NAME}" --help 2>&1 | grep -q -- '-port'; then
    log_info "Binary supports custom port. Setting to ${CUSTOM_PORT}"
    exec_opts="${exec_opts} --port ${CUSTOM_PORT}"
else
    CUSTOM_PORT="8080"
    log_warning "Binary does not support custom port. Defaulting to ${CUSTOM_PORT}"
fi
 ```
   
 Verifies whether the output of `--help` flag on binary has support for `-port`. 
 If it does, accepts users custom port 
 if it doesn't, defaults to 8080. 
 
 - Example usage, 
 ```
eBPF MCP Server Installer

Usage: ./install.sh [OPTIONS] [VERSION]

Options:
  --uninstall       Remove eBPF MCP Server
  --version         Show installed version
  --help, -h        Show this help message
  --port, -p <PORT> Run server on custom port (default: 8080)

Examples:
  curl -fsSL https://raw.githubusercontent.com/sameehj/ebpf-mcp/main/install.sh | sudo bash
  sudo ./install.sh v1.0.0
  sudo ./install.sh --port 9090
  sudo ./install.sh --uninstall
```